### PR TITLE
[extension] single source of truth for address

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,28 @@
+name: Build Extension
+on:
+  push:
+    branches: [ main ]
+    paths: [ fc-community-extension/** ]
+jobs:
+  code-checks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./fc-community-extension
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build extension
+        run: yarn run build
+
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: '[extension] update build folder'
+          file_pattern: ./fc-community-extension/factchain-extension-build/*
+          commit_user_name: Factchain Bot
+          commit_user_email: bot@factchain.tech
+          commit_author: Factchain Bot <bot@factchain.tech>

--- a/fc-community-extension/public/manifest.json
+++ b/fc-community-extension/public/manifest.json
@@ -25,7 +25,9 @@
       "js": ["statusContentScript.js"]
     }
   ],
-  "permissions": [],
+  "permissions": [
+    "storage"
+  ],
   "host_permissions": [
     "https://fc-community-backend-15f6c753d352.herokuapp.com/*"
   ],

--- a/fc-community-extension/public/manifest.json
+++ b/fc-community-extension/public/manifest.json
@@ -25,9 +25,7 @@
       "js": ["statusContentScript.js"]
     }
   ],
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage"],
   "host_permissions": [
     "https://fc-community-backend-15f6c753d352.herokuapp.com/*"
   ],

--- a/fc-community-extension/src/contentModifiers.js
+++ b/fc-community-extension/src/contentModifiers.js
@@ -1,5 +1,4 @@
 import { logger } from './utils/logging';
-import { createFactchainProvider } from './utils/web3';
 import { parseUrl, NOTE_URL_REGEX, POST_URL_REGEX } from './utils/constants';
 import { xSelectors } from './utils/selectors';
 
@@ -167,22 +166,24 @@ const makeFactchainHtmlNote = (isAuthor, content, rateNoteButtonID) => {
   `;
 
   if (rateNoteButtonID) {
-    noteHTML += `<div>${rateItHtml(rateNoteButtonID)}</div></div>`;
+    noteHTML += `<div>${rateItHtml(rateNoteButtonID)}</div>`;
   }
+  noteHTML += '</div>';
   return noteHTML;
 };
 
 const addNote = async (mainArticle, note) => {
-  const provider = await createFactchainProvider();
-  const userAddress = await provider.getAddress();
+  const {address} = await chrome.runtime.sendMessage({
+    type: 'fc-get-address',
+  });
   const isAuthor =
-    userAddress &&
-    userAddress.toLowerCase() === note.creatorAddress.toLowerCase();
+    address &&
+    address.toLowerCase() === note.creatorAddress.toLowerCase();
   const rateNoteButtonID =
     !note.finalRating && !isAuthor
       ? `#rateNoteButton-${note.creatorAddress}`
       : null;
-  let htmlNote = makeFactchainHtmlNote(
+  const htmlNote = makeFactchainHtmlNote(
     isAuthor,
     note.content,
     rateNoteButtonID

--- a/fc-community-extension/src/contentModifiers.js
+++ b/fc-community-extension/src/contentModifiers.js
@@ -173,12 +173,11 @@ const makeFactchainHtmlNote = (isAuthor, content, rateNoteButtonID) => {
 };
 
 const addNote = async (mainArticle, note) => {
-  const {address} = await chrome.runtime.sendMessage({
+  const { address } = await chrome.runtime.sendMessage({
     type: 'fc-get-address',
   });
   const isAuthor =
-    address &&
-    address.toLowerCase() === note.creatorAddress.toLowerCase();
+    address && address.toLowerCase() === note.creatorAddress.toLowerCase();
   const rateNoteButtonID =
     !note.finalRating && !isAuthor
       ? `#rateNoteButton-${note.creatorAddress}`

--- a/fc-community-extension/src/defaultContentScript.js
+++ b/fc-community-extension/src/defaultContentScript.js
@@ -5,6 +5,7 @@ import {
   alterMainPageTwitterNote,
 } from './contentModifiers';
 import { xSelectors } from './utils/selectors';
+import { createFactchainProvider } from './utils/web3';
 
 let observer = new MutationObserver(async (mutations) => {
   for (let mutation of mutations) {
@@ -45,4 +46,5 @@ let observer = new MutationObserver(async (mutations) => {
     }
   }
 });
+
 observer.observe(document, { childList: true, subtree: true });

--- a/fc-community-extension/src/pages/popup.js
+++ b/fc-community-extension/src/pages/popup.js
@@ -142,17 +142,24 @@ function FCPopup({ provider }) {
   const [address, setAddress] = createSignal('');
   const loggedIn = () => !!address();
 
+  const setCurrentAddress = async (address) => {
+    await chrome.runtime.sendMessage({
+      type: 'fc-set-address',
+      address,
+    });
+    setAddress(address);
+  };
   const changeConnectionState = async () => {
     if (loggedIn()) {
       await provider.disconnect();
-      setAddress('');
+      setCurrentAddress('');
     } else {
-      await provider.requestAddress().then(setAddress);
+      await provider.requestAddress().then(setCurrentAddress);
     }
   };
   const connectWallet = async () => {
     setSelectedTab('Profile');
-    await provider.requestAddress().then(setAddress);
+    await provider.requestAddress().then(setCurrentAddress);
   };
   const getUserStats = async (address) => {
     console.log(`address: ${address}`);
@@ -182,7 +189,7 @@ function FCPopup({ provider }) {
     userStats.loading || !userStats() ? '?' : userStats().ratings;
   const earnings = () =>
     userStats.loading || !userStats() ? '? ETH' : userStats().earnings;
-  provider.getAddress().then(setAddress);
+  provider.getAddress().then(setCurrentAddress);
 
   return (
     <div style="height:575px; width: 340px;">

--- a/fc-community-extension/src/pages/popup.js
+++ b/fc-community-extension/src/pages/popup.js
@@ -4,7 +4,7 @@ import { createFactchainProvider } from '../utils/web3';
 import { FCHero, FCLoader } from './components';
 import { getNotes } from '../utils/backend';
 import { ethers } from 'ethers';
-import { cutText } from '../utils/constants';
+import { cutText, elipseText } from '../utils/constants';
 
 function FCProfile(props) {
   function StatCard(props) {
@@ -23,7 +23,7 @@ function FCProfile(props) {
           Account
         </div>
         <div style="font-size: 110%; width: 100%; position: relative; left: 50%; transform: translateX(-50%); text-align: center;">
-          {props.loggedIn ? props.address : '0x?'}
+          {props.loggedIn ? elipseText(props.address, 20) : '0x?'}
         </div>
         <div style="margin-top: 40px; margin: 30px; display: flex; flex-direction: row; justify-content: space-between;">
           <StatCard name="Notes" value={props.numberNotes} />

--- a/fc-community-extension/src/pages/popup.js
+++ b/fc-community-extension/src/pages/popup.js
@@ -142,24 +142,18 @@ function FCPopup({ provider }) {
   const [address, setAddress] = createSignal('');
   const loggedIn = () => !!address();
 
-  const setCurrentAddress = async (address) => {
-    await chrome.runtime.sendMessage({
-      type: 'fc-set-address',
-      address,
-    });
-    setAddress(address);
-  };
   const changeConnectionState = async () => {
+    setSelectedTab('Profile');
     if (loggedIn()) {
       await provider.disconnect();
-      setCurrentAddress('');
+      await chrome.runtime.sendMessage({
+        type: 'fc-set-address',
+        address: '',
+      });
+      setAddress('');
     } else {
-      await provider.requestAddress().then(setCurrentAddress);
+      await provider.requestAddress().then(setAddress);
     }
-  };
-  const connectWallet = async () => {
-    setSelectedTab('Profile');
-    await provider.requestAddress().then(setCurrentAddress);
   };
   const getUserStats = async (address) => {
     console.log(`address: ${address}`);
@@ -189,7 +183,7 @@ function FCPopup({ provider }) {
     userStats.loading || !userStats() ? '?' : userStats().ratings;
   const earnings = () =>
     userStats.loading || !userStats() ? '? ETH' : userStats().earnings;
-  provider.getAddress().then(setCurrentAddress);
+  provider.getAddress().then(setAddress);
 
   return (
     <div style="height:575px; width: 340px;">
@@ -210,14 +204,14 @@ function FCPopup({ provider }) {
           <FCNotes
             loggedIn={loggedIn()}
             queryparams={{ creatorAddress: address() }}
-            connectWallet={connectWallet}
+            connectWallet={changeConnectionState}
           />
         </Match>
         <Match when={selectedTab() === 'Ratings'}>
           <FCNotes
             loggedIn={loggedIn()}
             queryparams={{ awaitingRatingBy: address() }}
-            connectWallet={connectWallet}
+            connectWallet={changeConnectionState}
           />
         </Match>
       </Switch>

--- a/fc-community-extension/src/serviceWorker.js
+++ b/fc-community-extension/src/serviceWorker.js
@@ -74,9 +74,9 @@ const mainHandler = async (message, sendResponse) => {
     console.log(`Address set to ${message.address} in storage`);
     sendResponse(true);
   } else if (message.type === 'fc-get-address') {
-    const address = (await chrome.storage.local.get(["address"])).address || '';
+    const address = (await chrome.storage.local.get(['address'])).address || '';
     console.log(`Retrieved address ${address} from storage`);
-    sendResponse({address});
+    sendResponse({ address });
   }
   /// For now we deactivate notifications
   ///

--- a/fc-community-extension/src/serviceWorker.js
+++ b/fc-community-extension/src/serviceWorker.js
@@ -69,6 +69,14 @@ const mainHandler = async (message, sendResponse) => {
       top: 0,
       left: 0,
     });
+  } else if (message.type === 'fc-set-address') {
+    await chrome.storage.local.set({ address: message.address });
+    console.log(`Address set to ${message.address} in storage`);
+    sendResponse(true);
+  } else if (message.type === 'fc-get-address') {
+    const address = (await chrome.storage.local.get(["address"])).address || '';
+    console.log(`Retrieved address ${address} from storage`);
+    sendResponse({address});
   }
   /// For now we deactivate notifications
   ///

--- a/fc-community-extension/src/utils/constants.js
+++ b/fc-community-extension/src/utils/constants.js
@@ -14,6 +14,13 @@ export const parseUrl = (url, regex) => sanitizeXUrl(url.match(regex)[1]);
 export const cutText = (text, maxLength) => {
   return text.length < maxLength ? text : `${text.slice(0, maxLength)}...`;
 };
+export const elipseText = (text, maxLength) => {
+  return (
+    text.length < maxLength ?
+    text :
+    `${text.slice(0, Math.floor(maxLength / 2))}...${text.slice(text.length - Math.floor(maxLength / 2))}`
+  );
+};
 export const makeTransactionUrl = (transactionHash) =>
   `https://sepolia.etherscan.io/tx/${transactionHash}`;
 export const makeOpenseaUrl = (contractAddress, tokenId) =>

--- a/fc-community-extension/src/utils/constants.js
+++ b/fc-community-extension/src/utils/constants.js
@@ -15,11 +15,11 @@ export const cutText = (text, maxLength) => {
   return text.length < maxLength ? text : `${text.slice(0, maxLength)}...`;
 };
 export const elipseText = (text, maxLength) => {
-  return (
-    text.length < maxLength ?
-    text :
-    `${text.slice(0, Math.floor(maxLength / 2))}...${text.slice(text.length - Math.floor(maxLength / 2))}`
-  );
+  return text.length < maxLength
+    ? text
+    : `${text.slice(0, Math.floor(maxLength / 2))}...${text.slice(
+        text.length - Math.floor(maxLength / 2)
+      )}`;
 };
 export const makeTransactionUrl = (transactionHash) =>
   `https://sepolia.etherscan.io/tx/${transactionHash}`;

--- a/fc-community-extension/src/utils/web3.js
+++ b/fc-community-extension/src/utils/web3.js
@@ -62,7 +62,7 @@ export const createFactchainProvider = async () => {
     const getAccounts = async (requestAccess) => {
       logger.log(`Get accounts, requestAccess=${requestAccess}`);
       const method = requestAccess ? 'eth_requestAccounts' : 'eth_accounts';
-      const accounts = await provider.request({method});
+      const accounts = await provider.request({ method });
       logger.log('Received accounts', accounts);
       await chrome.runtime.sendMessage({
         type: 'fc-set-address',
@@ -100,9 +100,12 @@ export const createFactchainProvider = async () => {
         });
       },
       getFCContract: async () => getContract('main', FC_CONTRACT_ABI),
-      onFCEvents: async (topics, callback) => onContractEvents('main', topics, callback),
-      getFC1155Contract: async () => getContract('nft1155', FC_1155_CONTRACT_ABI),
-      onFC1155Events: async (topics, callback) => onContractEvents('nft1155', topics, callback),
+      onFCEvents: async (topics, callback) =>
+        onContractEvents('main', topics, callback),
+      getFC1155Contract: async () =>
+        getContract('nft1155', FC_1155_CONTRACT_ABI),
+      onFC1155Events: async (topics, callback) =>
+        onContractEvents('nft1155', topics, callback),
     };
   } catch (e) {
     console.error(`Metamask connect error `, e);

--- a/fc-community-extension/src/utils/web3.js
+++ b/fc-community-extension/src/utils/web3.js
@@ -59,26 +59,36 @@ export const createFactchainProvider = async () => {
       ],
     });
 
+    const getAccounts = async (requestAccess) => {
+      logger.log(`Get accounts, requestAccess=${requestAccess}`);
+      const method = requestAccess ? 'eth_requestAccounts' : 'eth_accounts';
+      const accounts = await provider.request({method});
+      logger.log('Received accounts', accounts);
+      await chrome.runtime.sendMessage({
+        type: 'fc-set-address',
+        address: accounts[0],
+      });
+      return accounts;
+    };
+    const getContract = async (contractName, contractAbi) => {
+      const ethersProvider = new ethers.BrowserProvider(provider);
+      const signer = await ethersProvider.getSigner();
+      const contractAddress = (await getContracts())[contractName];
+      return new ethers.Contract(contractAddress, contractAbi, signer);
+    };
+    const onContractEvents = async (contractName, topics, callback) => {
+      const contractAddress = (await getContracts())[contractName];
+      filter = {
+        address: contractAddress,
+        topics: topics.map(utils.id),
+      };
+      provider.on(filter, callback);
+    };
+
     return {
-      getAddress: async () => {
-        logger.log('Getting accounts');
-        const accounts = await provider.request({ method: 'eth_accounts' });
-        logger.log('Received accounts', accounts);
-        return accounts[0];
-      },
-      requestAddress: async () => {
-        logger.log('Requesting access to accounts');
-        const accounts = await provider.request({
-          method: 'eth_requestAccounts',
-        });
-        logger.log('Received accounts', accounts);
-        return accounts[0];
-      },
-      onAddressChange: (handler) => {
-        provider.on('accountsChanged', (accounts) => {
-          handler(accounts.length === 0 ? null : accounts[0]);
-        });
-      },
+      getAddresses: async () => await getAccounts(false),
+      getAddress: async () => (await getAccounts(false))[0],
+      requestAddress: async () => (await getAccounts(true))[0],
       disconnect: async () => {
         return provider.request({
           method: 'wallet_revokePermissions',
@@ -89,38 +99,10 @@ export const createFactchainProvider = async () => {
           ],
         });
       },
-      getFCContract: async () => {
-        const ethersProvider = new ethers.BrowserProvider(provider);
-        const signer = await ethersProvider.getSigner();
-        const fcContractAddress = (await getContracts()).main;
-        return new ethers.Contract(fcContractAddress, FC_CONTRACT_ABI, signer);
-      },
-      onFCEvents: async (topics, callback) => {
-        const fcContractAddress = (await getContracts()).main;
-        filter = {
-          address: fcContractAddress,
-          topics: topics.map(utils.id),
-        };
-        provider.on(filter, callback);
-      },
-      getFC1155Contract: async () => {
-        const ethersProvider = new ethers.BrowserProvider(provider);
-        const signer = await ethersProvider.getSigner();
-        const fc1155ContractAddress = (await getContracts()).nft1155;
-        return new ethers.Contract(
-          fc1155ContractAddress,
-          FC_1155_CONTRACT_ABI,
-          signer
-        );
-      },
-      onFC1155Events: async (topics, callback) => {
-        const fc1155ContractAddress = (await getContracts()).nft1155;
-        filter = {
-          address: fc1155ContractAddress,
-          topics: topics.map(utils.id),
-        };
-        provider.on(filter, callback);
-      },
+      getFCContract: async () => getContract('main', FC_CONTRACT_ABI),
+      onFCEvents: async (topics, callback) => onContractEvents('main', topics, callback),
+      getFC1155Contract: async () => getContract('nft1155', FC_1155_CONTRACT_ABI),
+      onFC1155Events: async (topics, callback) => onContractEvents('nft1155', topics, callback),
     };
   } catch (e) {
     console.error(`Metamask connect error `, e);

--- a/fc-community-extension/src/utils/web3.js
+++ b/fc-community-extension/src/utils/web3.js
@@ -37,24 +37,6 @@ export const makeTransactionCall = async (contract, transactionCall) => {
   return { transaction, error };
 };
 
-export const mintXNote = async (noteId, value, hash, signature) => {
-  logger.log('Minting X note', noteId, value, hash, signature);
-  const provider = await createFactchainProvider();
-  const contract = await provider.getFC1155Contract();
-
-  return await makeTransactionCall(
-    contract,
-    async (c) =>
-      await c.mint(
-        noteId,
-        value,
-        hash.startsWith('0x') ? hash : `0x${hash}`,
-        signature,
-        { value: value * 1_000_000 }
-      )
-  );
-};
-
 export const createFactchainProvider = async () => {
   try {
     let currentMetaMaskId = METAMASK_ID;


### PR DESCRIPTION
The address used for different actions (rate/create note, show owner's notes in the popup, ...) was not always the same.

This was caused by having both twitter.com and our extension to connect to metamask separately.

Instead we now always connect from the extension code, and we set the selected address in the storage of the extension so that code running on twitter.com can still retrieve it.

Also cleaned things up a bit, and did a refactoring of web3.js.