### PR TITLE
Admin roles

### DIFF
--- a/fc-community-contracts/src/FactchainCommunity.sol
+++ b/fc-community-contracts/src/FactchainCommunity.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import {stdMath} from "forge-std/StdMath.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -74,9 +75,11 @@ interface IFactchainCommunity is IFactchainCommunityEvents {
 /// @author Yacine B. Badiss, Pierre HAY
 /// @notice
 /// @dev
-contract FactchainCommunity is Initializable, OwnableUpgradeable, UUPSUpgradeable, IFactchainCommunity {
+contract FactchainCommunity is Initializable, OwnableUpgradeable, AccessControlUpgradeable, UUPSUpgradeable, IFactchainCommunity {
     uint8 internal constant POST_URL_MAX_LENGTH = 160;
     uint16 internal constant CONTENT_MAX_LENGTH = 500;
+    bytes32 public constant FINALISER_ROLE = keccak256("FINALISER_ROLE");
+
     uint64 public minimumStakePerNote;
     uint64 public minimumStakePerRating;
 
@@ -273,21 +276,14 @@ contract FactchainCommunity is Initializable, OwnableUpgradeable, UUPSUpgradeabl
     /// Owner actions
     ////////////////////////////////////////////////////////////////////////
 
+    function _transferOwnership(address newOwner) override internal virtual {
+        super._transferOwnership(newOwner);
+        _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+    }
+
     // @notice Fund the contract
     receive() external payable onlyOwner {
         emit ReserveFunded(msg.value);
-    }
-
-    /// @notice Finalise a note
-    function finaliseNote(string memory _postUrl, address _creator, uint8 _finalRating) external onlyOwner {
-        if (!isRatingValid(_finalRating)) revert RatingInvalid();
-        if (!noteExists(_postUrl, _creator)) revert NoteDoesNotExist();
-        if (isNoteFinalised(_postUrl, _creator)) revert NoteAlreadyFinalised();
-
-        communityNotes[_postUrl][_creator].finalRating = _finalRating;
-        rewardOrSlashCreator(_postUrl, _creator);
-        rewardOrSlashRaters(_postUrl, _creator);
-        emit NoteFinalised({postUrl: _postUrl, creator: _creator, finalRating: _finalRating});
     }
 
     /// @notice Set minimum staking for note creation
@@ -300,5 +296,22 @@ contract FactchainCommunity is Initializable, OwnableUpgradeable, UUPSUpgradeabl
     function setMinimumStakePerRating(uint64 _minimumStakePerRating) external onlyOwner {
         minimumStakePerRating = _minimumStakePerRating;
         emit MinimumStakePerRatingUpdated(minimumStakePerRating);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    /// Finaliser actions
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Finalise a note
+    function finaliseNote(string memory _postUrl, address _creator, uint8 _finalRating) external {
+        require(hasRole(FINALISER_ROLE, msg.sender));
+        if (!isRatingValid(_finalRating)) revert RatingInvalid();
+        if (!noteExists(_postUrl, _creator)) revert NoteDoesNotExist();
+        if (isNoteFinalised(_postUrl, _creator)) revert NoteAlreadyFinalised();
+
+        communityNotes[_postUrl][_creator].finalRating = _finalRating;
+        rewardOrSlashCreator(_postUrl, _creator);
+        rewardOrSlashRaters(_postUrl, _creator);
+        emit NoteFinalised({postUrl: _postUrl, creator: _creator, finalRating: _finalRating});
     }
 }

--- a/fc-community-contracts/src/FactchainCommunity.sol
+++ b/fc-community-contracts/src/FactchainCommunity.sol
@@ -303,8 +303,7 @@ contract FactchainCommunity is Initializable, OwnableUpgradeable, AccessControlU
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Finalise a note
-    function finaliseNote(string memory _postUrl, address _creator, uint8 _finalRating) external {
-        require(hasRole(FINALISER_ROLE, msg.sender));
+    function finaliseNote(string memory _postUrl, address _creator, uint8 _finalRating) external onlyRole(FINALISER_ROLE) {
         if (!isRatingValid(_finalRating)) revert RatingInvalid();
         if (!noteExists(_postUrl, _creator)) revert NoteDoesNotExist();
         if (isNoteFinalised(_postUrl, _creator)) revert NoteAlreadyFinalised();

--- a/fc-community-contracts/src/FactchainNFT.sol
+++ b/fc-community-contracts/src/FactchainNFT.sol
@@ -6,6 +6,7 @@ import {ERC721URIStorageUpgradeable} from
 import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 contract FactchainSFT {
     function initialMint(address creator, address[] memory raters, string memory ipfsHash, uint256 id)
@@ -22,11 +23,12 @@ interface IFactchainSFTEvents {
 /// @author Pierre HAY
 /// @notice
 /// @dev
-contract FactchainNFT is OwnableUpgradeable, ERC721URIStorageUpgradeable, UUPSUpgradeable, IFactchainSFTEvents {
+contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URIStorageUpgradeable, UUPSUpgradeable, IFactchainSFTEvents {
     FactchainSFT factsLithography;
     uint256 public tokenIdCounter;
     string private baseTokenURI;
     mapping(string => mapping(address => uint256)) public noteIds;
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     // disable contract until initialization
     constructor() {
@@ -44,12 +46,39 @@ contract FactchainNFT is OwnableUpgradeable, ERC721URIStorageUpgradeable, UUPSUp
         factsLithography = FactchainSFT(_factsLitography);
     }
 
+    ////////////////////////////////////////////////////////////////////////
+    /// Internal functions
+    ////////////////////////////////////////////////////////////////////////
+
     function _authorizeUpgrade(address /* newImplementation */ ) internal view override onlyOwner {}
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    /// Owner actions
+    ////////////////////////////////////////////////////////////////////////
+
+    function _transferOwnership(address newOwner) override internal virtual {
+        super._transferOwnership(newOwner);
+        _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+    }
 
     function setFactchainSFTContract(address _factsLitography) public onlyOwner {
         factsLithography = FactchainSFT(_factsLitography);
         emit FactchainSFTContractUpdated(_factsLitography);
     }
+
+    /// @notice set a new baseTokenURI
+    /// @param _baseTokenURI the new base token URI
+    function setBaseURI(string memory _baseTokenURI) public onlyOwner {
+        baseTokenURI = _baseTokenURI;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    /// Minter action
+    ////////////////////////////////////////////////////////////////////////
 
     /// @notice mint a NFT
     /// @param creator destination address for the orginal fact (NFT-721)
@@ -57,9 +86,9 @@ contract FactchainNFT is OwnableUpgradeable, ERC721URIStorageUpgradeable, UUPSUp
     /// @param ipfsHash metadata ID on ipfs shared by the original and its copies
     function mint(address creator, string memory postUrl, address[] memory raters, string memory ipfsHash)
         public
-        onlyOwner
         returns (uint256)
     {
+        require(hasRole(MINTER_ROLE, msg.sender));
         unchecked {
             // An overflow here would be a great collective achievement (2**256 factchain notes)
             ++tokenIdCounter;
@@ -72,13 +101,11 @@ contract FactchainNFT is OwnableUpgradeable, ERC721URIStorageUpgradeable, UUPSUp
         return newItemId;
     }
 
-    function _baseURI() internal view override returns (string memory) {
-        return baseTokenURI;
-    }
+    ////////////////////////////////////////////////////////////////////////
+    /// Interface functions
+    ////////////////////////////////////////////////////////////////////////
 
-    /// @notice set a new baseTokenURI
-    /// @param _baseTokenURI the new base token URI
-    function setBaseURI(string memory _baseTokenURI) public onlyOwner {
-        baseTokenURI = _baseTokenURI;
+    function supportsInterface(bytes4 interfaceId) public view virtual override (ERC721URIStorageUpgradeable, AccessControlUpgradeable) returns (bool) {
+        return ERC721URIStorageUpgradeable.supportsInterface(interfaceId) || AccessControlUpgradeable.supportsInterface(interfaceId);
     }
 }

--- a/fc-community-contracts/src/FactchainNFT.sol
+++ b/fc-community-contracts/src/FactchainNFT.sol
@@ -16,7 +16,7 @@ contract FactchainSFT {
 }
 
 interface IFactchainSFTEvents {
-    event FactchainSFTContractUpdated(address factsLithography);
+    event FactchainSFTContractUpdated(address truthFragments);
 }
 
 /// @title Factchainers Community Notes NFT
@@ -24,7 +24,7 @@ interface IFactchainSFTEvents {
 /// @notice
 /// @dev
 contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URIStorageUpgradeable, UUPSUpgradeable, IFactchainSFTEvents {
-    FactchainSFT factsLithography;
+    FactchainSFT truthFragments;
     uint256 public tokenIdCounter;
     string private baseTokenURI;
     mapping(string => mapping(address => uint256)) public noteIds;
@@ -35,7 +35,7 @@ contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URI
         _disableInitializers();
     }
 
-    function initialize(address _owner, address _factsLitography, string memory _baseTokenURI) public initializer {
+    function initialize(address _owner, address _truthFragments, string memory _baseTokenURI) public initializer {
         __ERC721_init("FactchainNotes", "FCN");
         __ERC721URIStorage_init();
         __Ownable_init(_owner);
@@ -43,7 +43,7 @@ contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URI
 
         tokenIdCounter = 0;
         baseTokenURI = _baseTokenURI;
-        factsLithography = FactchainSFT(_factsLitography);
+        truthFragments = FactchainSFT(_truthFragments);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -65,9 +65,9 @@ contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URI
         _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
     }
 
-    function setFactchainSFTContract(address _factsLitography) public onlyOwner {
-        factsLithography = FactchainSFT(_factsLitography);
-        emit FactchainSFTContractUpdated(_factsLitography);
+    function setFactchainSFTContract(address _truthFragments) public onlyOwner {
+        truthFragments = FactchainSFT(_truthFragments);
+        emit FactchainSFTContractUpdated(_truthFragments);
     }
 
     /// @notice set a new baseTokenURI
@@ -96,7 +96,7 @@ contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URI
         uint256 newItemId = tokenIdCounter;
         _safeMint(creator, newItemId);
         _setTokenURI(newItemId, ipfsHash);
-        factsLithography.initialMint(creator, raters, ipfsHash, newItemId);
+        truthFragments.initialMint(creator, raters, ipfsHash, newItemId);
         noteIds[postUrl][creator] = newItemId;
         return newItemId;
     }

--- a/fc-community-contracts/src/FactchainNFT.sol
+++ b/fc-community-contracts/src/FactchainNFT.sol
@@ -86,9 +86,9 @@ contract FactchainNFT is OwnableUpgradeable, AccessControlUpgradeable, ERC721URI
     /// @param ipfsHash metadata ID on ipfs shared by the original and its copies
     function mint(address creator, string memory postUrl, address[] memory raters, string memory ipfsHash)
         public
+        onlyRole(MINTER_ROLE)
         returns (uint256)
     {
-        require(hasRole(MINTER_ROLE, msg.sender));
         unchecked {
             // An overflow here would be a great collective achievement (2**256 factchain notes)
             ++tokenIdCounter;

--- a/fc-community-contracts/test/FactchainCommunity.t.sol
+++ b/fc-community-contracts/test/FactchainCommunity.t.sol
@@ -245,7 +245,7 @@ contract FactchainCommunityTest is Test, IFactchainCommunity {
         });
     }
 
-    function test_finaliseNote_RevertIf_notOwner() public {
+    function test_finaliseNote_RevertIf_notFinaliser() public {
         uint256 minimumStakePerNote = fcCommunity.minimumStakePerNote();
         hoax(player1);
         fcCommunity.createNote{value: minimumStakePerNote}({

--- a/fc-community-contracts/test/FactchainCommunity.t.sol
+++ b/fc-community-contracts/test/FactchainCommunity.t.sol
@@ -253,7 +253,7 @@ contract FactchainCommunityTest is Test, IFactchainCommunity {
             _content: "Something something something"
         });
 
-        vm.startPrank(rater1);
+        vm.startPrank(theOwner);
         // following specif expectRevert should work ...
         // vm.expectRevert(OwnableUpgradeable.OwnableUnauthorizedAccount.selector);
         vm.expectRevert();

--- a/fc-community-contracts/test/FactchainNFT.t.sol
+++ b/fc-community-contracts/test/FactchainNFT.t.sol
@@ -7,11 +7,13 @@ import {FactchainProxy} from "../src/FactchainProxy.sol";
 
 contract FactchainNFTTest is Test {
     FactchainNFT collection;
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     address public owner = address(1);
-    address public recipient = address(2);
-    address public factChainSFT = address(3);
-    address[] public raters = [address(4), address(5)];
+    address public admin = address(2);
+    address public recipient = address(3);
+    address public factChainSFT = address(4);
+    address[] public raters = [address(5), address(6)];
     string public postUrl = "https://twitter.com/rektorship/status/1750724519705153835";
 
     function setUp() public {
@@ -19,10 +21,24 @@ contract FactchainNFTTest is Test {
         FactchainProxy proxy =
         new FactchainProxy(address(implementation), abi.encodeCall(collection.initialize, (owner, factChainSFT, "https://gateway.pinata.cloud/ipfs/")));
         collection = FactchainNFT(payable(address(proxy)));
+
+        hoax(owner);
+        collection.grantRole(MINTER_ROLE, admin);
+    }
+
+    function test_mint() public {
+        vm.prank(admin);
+        collection.mint(recipient, postUrl, raters, "QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv");
+    }
+
+    function test_mint_RevertIf_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(owner);
+        collection.mint(recipient, postUrl, raters, "QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv");
     }
 
     function testGetTokenURI() public {
-        vm.prank(owner);
+        vm.prank(admin);
         collection.mint(recipient, postUrl, raters, "QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv");
         assertEq(
             collection.tokenURI(1), "https://gateway.pinata.cloud/ipfs/QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv"
@@ -30,8 +46,9 @@ contract FactchainNFTTest is Test {
     }
 
     function testSetBaseURI() public {
-        vm.startPrank(owner);
+        vm.prank(owner);
         collection.setBaseURI("http://ipfs.com/");
+        vm.prank(admin);
         collection.mint(recipient, postUrl, raters, "QmNSYBE2J3gnDrwXJAVnL6KfCzKvsgnWFVpxzyUUWcDmtt");
         assertEq(collection.tokenURI(1), "http://ipfs.com/QmNSYBE2J3gnDrwXJAVnL6KfCzKvsgnWFVpxzyUUWcDmtt");
     }

--- a/fc-community-contracts/test/FactchainNFT.t.sol
+++ b/fc-community-contracts/test/FactchainNFT.t.sol
@@ -37,7 +37,7 @@ contract FactchainNFTTest is Test {
         collection.mint(recipient, postUrl, raters, "QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv");
     }
 
-    function testGetTokenURI() public {
+    function test_getTokenURI() public {
         vm.prank(admin);
         collection.mint(recipient, postUrl, raters, "QmdByzCXRCbPZ2DYq3wqURjShNEGZ2qDNW4w9mcwA9oWLv");
         assertEq(
@@ -45,7 +45,7 @@ contract FactchainNFTTest is Test {
         );
     }
 
-    function testSetBaseURI() public {
+    function test_setBaseURI() public {
         vm.prank(owner);
         collection.setBaseURI("http://ipfs.com/");
         vm.prank(admin);


### PR DESCRIPTION
Adding admin roles for main contract and nft contract.

The idea is to separate the manual operation our owner address will perform, from the automated actions our backend will have to do.

For the main contract:
- manual actions: fund the contract, set the minimum stake amounts
- automated actions: finalise a note

For the nft contract:
- manual actions: set sft contract address, set base uri
- automated actions: mint an NFT

The owner is also always the `DEFAULT_ADMIN` which means it is allowed to grant roles to other addresses.
This role base control is done through openzeppelin's `AccessControlUpgradeable`.

After deploying this upgrade we will have to
- [x] create 2 new priv key and their addresses `FINALISER_ADDRESS` and `MINTER_ADDRESS`
- [ ] call `grantRole(keccak256("FINALISER_ROLE"), FINALISER_ADDRESS)` on the main contract
- [ ] call `grantRole(keccak256("MINTER_ROLE"), MINTER_ADDRESS)` on the nft contract
- [ ] in backend
  - [ ] rename `NFT_CONTRACT_OWNER_PKEY` to `NFT_MINTER_PKEY` and `MAIN_CONTRACT_OWNER_PKEY` to `NOTE_FINALISER_PKEY` on the backend
  - [ ] change the env vars on the backend to have the new private keys
  - [ ] update the abis
- [ ] extension
  - [ ] update the abis